### PR TITLE
Fix CardHeader closing tag in daily activity page

### DIFF
--- a/src/app/(app)/daily-activity/page.tsx
+++ b/src/app/(app)/daily-activity/page.tsx
@@ -149,11 +149,11 @@ export default function DailyActivityPage() {
         <TabsContent value="summary">
           <Card>
             <CardHeader>
-                <CardTitle>Ringkasan Kinerja</CardTitle>
-                <CardDescription>
-                    Pantau kelengkapan pencatatan aktivitas Anda untuk tanggal yang dipilih di setiap kategori.
-                </CardDescription>
-            </Header>
+              <CardTitle>Ringkasan Kinerja</CardTitle>
+              <CardDescription>
+                Pantau kelengkapan pencatatan aktivitas Anda untuk tanggal yang dipilih di setiap kategori.
+              </CardDescription>
+            </CardHeader>
             <CardContent>
               <SummaryTab
                 activities={activities}


### PR DESCRIPTION
## Summary
- replace the incorrect closing `</Header>` tag in the daily activity summary card with `</CardHeader>`
- tidy the indentation to match the surrounding JSX structure

## Testing
- npm run lint *(fails to execute because the script prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68d4d2b286b8832481d381ecab160c58